### PR TITLE
Fix LinkedIn Link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,7 @@ projects:
 social_media:
   facebook: hightechu
   instagram: hightechu
-  linkedin: company/hightechu
+  linkedin: hightechu
   twitter: hightech_u
   website: https://www.hightechu.ca
   youtube: channel/UC2Mn8IgijRO-OF-DrWEq4KA?


### PR DESCRIPTION
Fixes #6 

Removed `company` from the LinkedIn config.